### PR TITLE
Add UE axis option

### DIFF
--- a/KKPanel.py
+++ b/KKPanel.py
@@ -179,6 +179,7 @@ class PlaceholderProperties(PropertyGroup):
 
     ue_apply_scale : BoolProperty(name="Apply UE Scale (100x)", description="Scales the model by 100x for Unreal Engine compatibility. Make sure this is checked if exporting for UE.", default=True)
     ue_triangulate_mesh : BoolProperty(name="Triangulate Mesh for UE", description="Converts all quads/n-gons to triangles before export for Unreal Engine.", default=False)
+    ue_fix_axis : BoolProperty(name="Set UE Axis", description="Export with Unreal Engine axis orientation (X forward, Z up).", default=True)
 
 #The main panel
 class IMPORTINGHEADER_PT_panel(bpy.types.Panel):
@@ -307,6 +308,10 @@ class EXPORTING_PT_panel(bpy.types.Panel):
         row = col.row(align=True)
         row.prop(context.scene.kkbp, "ue_triangulate_mesh")
         # Ensure the same enable conditions apply, especially scene.prep_dropdown == 'E'
+        row.enabled = scene.prep_dropdown == 'E' and scene.plugin_state in ['imported'] and bpy.context.scene.kkbp.armature_dropdown in ['A', 'C', 'D']
+
+        row = col.row(align=True)
+        row.prop(context.scene.kkbp, "ue_fix_axis")
         row.enabled = scene.prep_dropdown == 'E' and scene.plugin_state in ['imported'] and bpy.context.scene.kkbp.armature_dropdown in ['A', 'C', 'D']
 
 class EXTRAS_PT_panel(bpy.types.Panel):

--- a/exporting/bakematerials.py
+++ b/exporting/bakematerials.py
@@ -530,6 +530,9 @@ def create_material_atlas(folderpath: str):
         bpy.data.collections[c.get_name() + ' atlas'].exporters[0].export_properties.apply_scale_options = 'FBX_SCALE_ALL'
         bpy.data.collections[c.get_name() + ' atlas'].exporters[0].export_properties.path_mode = 'COPY'
         bpy.data.collections[c.get_name() + ' atlas'].exporters[0].export_properties.embed_textures = False
+        if ue_fix_axis:
+            bpy.data.collections[c.get_name() + ' atlas'].exporters[0].export_properties.axis_forward = '-Y'
+            bpy.data.collections[c.get_name() + ' atlas'].exporters[0].export_properties.axis_up = 'Z'
         bpy.data.collections[c.get_name() + ' atlas'].exporters[0].export_properties.mesh_smooth_type = 'OFF'
         bpy.data.collections[c.get_name() + ' atlas'].exporters[0].export_properties.filepath = os.path.join(folderpath.replace('baked_files', 'atlas_files'), f'{sanitizeMaterialName(c.get_name())} exported model atlas.fbx')
 
@@ -551,6 +554,7 @@ class bake_materials(bpy.types.Operator):
         try:
             #just use the pmx folder for the baked files
             scene = context.scene.kkbp
+            ue_fix_axis = scene.ue_fix_axis
             folderpath = os.path.join(context.scene.kkbp.import_dir, 'baked_files', '')
             last_step = time.time()
             c.toggle_console()
@@ -641,6 +645,9 @@ class bake_materials(bpy.types.Operator):
                     bpy.data.collections[c.get_name()].exporters[0].export_properties.apply_scale_options = 'FBX_SCALE_ALL'
                     bpy.data.collections[c.get_name()].exporters[0].export_properties.path_mode = 'COPY'
                     bpy.data.collections[c.get_name()].exporters[0].export_properties.embed_textures = False
+                    if ue_fix_axis:
+                        bpy.data.collections[c.get_name()].exporters[0].export_properties.axis_forward = '-Y'
+                        bpy.data.collections[c.get_name()].exporters[0].export_properties.axis_up = 'Z'
                     bpy.data.collections[c.get_name()].exporters[0].export_properties.mesh_smooth_type = 'OFF'
                     bpy.data.collections[c.get_name()].exporters[0].export_properties.filepath = os.path.join(folderpath.replace('baked_files', 'atlas_files'), f'{sanitizeMaterialName(c.get_name())} exported model.fbx')
             c.toggle_console()

--- a/wiki/export_panel.md
+++ b/wiki/export_panel.md
@@ -64,3 +64,6 @@ Additionally, you have the following options when "Unreal Engine" is selected:
 *   **Triangulate Mesh for UE:**
     *   Default: Off
     *   If enabled, this option will convert all mesh geometry (quads and n-gons) into triangles before export. While Unreal Engine can triangulate meshes on import, doing it in Blender first can give you more control over the final triangulation and help avoid potential issues.
+*   **Set UE Axis:**
+    *   Default: On
+    *   Configures the FBX exporter to use Unreal's axis setup (X forward, Z up). Disable this if you need custom axis settings.


### PR DESCRIPTION
## Summary
- add UE axis toggle to exporter panel and include in docs
- configure FBX exporter to use UE forward/up axes when enabled

## Testing
- `python3 -m py_compile __init__.py KKPanel.py exporting/*.py preferences.py common.py extras/*.py importing/*.py interface/*py`


------
https://chatgpt.com/codex/tasks/task_e_684158b93a2483228a1c764d8832af7d