### PR TITLE
Fix duplicate import in preferences

### DIFF
--- a/preferences.py
+++ b/preferences.py
@@ -5,8 +5,6 @@ from bpy.props import BoolProperty, EnumProperty, StringProperty
 
 from .interface.dictionary_en import t
 
-from .interface.dictionary_en import t
-
 class KKBPPreferences(bpy.types.AddonPreferences):
     # this must match the add-on name, use '__package__'
     # when defining this in a submodule of a python package.


### PR DESCRIPTION
## Summary
- remove duplicate dictionary import in `preferences.py`

## Testing
- `python -m py_compile preferences.py`

------
https://chatgpt.com/codex/tasks/task_e_6841660408348322880ab5b2fdc15b65