### PR TITLE
Fix duplicate bake property declarations

### DIFF
--- a/preferences.py
+++ b/preferences.py
@@ -48,17 +48,6 @@ class KKBPPreferences(bpy.types.AddonPreferences):
     description=t('dark_F_tt'),
     default = True)
 
-    bake_light_bool : BoolProperty(
-    description=t('bake_light_tt'),
-    default = True)
-
-    bake_dark_bool : BoolProperty(
-    description=t('bake_dark_tt'),
-    default = True)
-
-    bake_norm_bool : BoolProperty(
-    description=t('bake_norm_tt'),
-    default = False)
 
     use_atlas : BoolProperty(
     description=t('use_atlas'),


### PR DESCRIPTION
## Summary
- remove duplicate bake bool declarations
- keep draw() referencing bake bools

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684bc5223e2c832295bbf254a80ff971