### PR TITLE
Add code style tools

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 25.1.0
+    hooks:
+      - id: black
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.2.0
+    hooks:
+      - id: flake8

--- a/README.md
+++ b/README.md
@@ -26,6 +26,20 @@ If you want to add or make changes to [the wiki site](https://kkbpwiki.github.io
 If you're interested in translating the plugin's interface into another language, [check this folder for examples](https://github.com/FlailingFog/KK-Blender-Porter-Pack/tree/master/interface).   
 This project does not accept donations.
 
+### Code style
+This project uses [black](https://github.com/psf/black) and
+[flake8](https://flake8.pycqa.org/) to keep the codebase consistent.
+Their configuration lives in `pyproject.toml` and can be run automatically
+via [pre-commit](https://pre-commit.com/).
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+Running these commands will enable automatic formatting and linting on each
+commit.
+
 ## Similar Projects
 
 * [KKBP Exporter](https://github.com/FlailingFog/KKBP_Exporter)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,8 @@
+[tool.black]
+line-length = 120
+target-version = ['py310']
+
+[tool.flake8]
+max-line-length = 120
+extend-ignore = ['E203', 'W503']
+


### PR DESCRIPTION
## Summary
- configure black and flake8 in `pyproject.toml`
- add a pre-commit config running black and flake8
- document code style and pre-commit usage in README

## Testing
- `pre-commit run --files README.md pyproject.toml .pre-commit-config.yaml`

------
https://chatgpt.com/codex/tasks/task_e_684bcf0bf0ac832295b5a6460790b7ec